### PR TITLE
Correction de la gestion de caractères accentués dans les chemins d'accès et correction de l'encodage des fichiers

### DIFF
--- a/default.py
+++ b/default.py
@@ -123,7 +123,7 @@ if MODE is not 99:
     xbmcplugin.endOfDirectory(int(sys.argv[1]))
 
 if MODE is not 4 and xbmcaddon.Addon().getSetting('DeleteTempFiFilesEnabled') == 'true':
-    PATH = xbmc.translatePath('special://temp')
+    PATH = xbmc.translatePath('special://temp').decode('utf-8')
     FILENAMES = next(os.walk(PATH))[2]
     for i in FILENAMES:
         if ".fi" in i:

--- a/default.py
+++ b/default.py
@@ -1,6 +1,5 @@
-# -*- coding: cp1252 -*-
+# -*- coding: utf-8 -*-
 
-""" -*- coding: utf-8 -*- """
 # version 3.0.0 - By CB
 # version 2.0.2 - By SlySen
 # version 0.2.6 - By CB

--- a/resources/lib/cache.py
+++ b/resources/lib/cache.py
@@ -8,7 +8,7 @@ import xbmcaddon, os, xbmc, time, sys, html
 
 ADDON = xbmcaddon.Addon()
 
-ADDON_CACHE_BASEDIR = os.path.join(xbmc.translatePath(ADDON.getAddonInfo('path')), ".cache")
+ADDON_CACHE_BASEDIR = os.path.join(xbmc.translatePath(ADDON.getAddonInfo('path')).decode('utf-8'), ".cache")
 ADDON_CACHE_TTL = float(ADDON.getSetting('CacheTTL').replace("0", ".5").replace("73", "0"))
 
 if not os.path.exists(ADDON_CACHE_BASEDIR):

--- a/resources/lib/cache.py
+++ b/resources/lib/cache.py
@@ -1,6 +1,5 @@
-# -*- coding: cp1252 -*-
+# -*- coding: utf-8 -*-
 
-""" -*- coding: utf-8 -*- """
 # version 3.0.0 - By CB
 # version 2.0.2 - By SlySen
 # version 0.2.6 - By CB
@@ -35,7 +34,7 @@ def get_cached_content(path):
         if os.path.exists(filename) and not is_cached_content_expired(os.path.getmtime(filename)):
             content = open(filename).read()
         else:
-            ###CB  ne devrait pas etre utilisé ici, mais en amont
+            ###CB  ne devrait pas etre utilisÃ© ici, mais en amont
             #check_for_internet_connection()
             content = html.get_url_txt(path)
             try:

--- a/resources/lib/clearcache.py
+++ b/resources/lib/clearcache.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 
 import os
 import sys

--- a/resources/lib/clearcache.py
+++ b/resources/lib/clearcache.py
@@ -9,7 +9,7 @@ import xbmcvfs
 from xbmcaddon import Addon
 
 addon = Addon('plugin.video.telequebec')
-addon_cache_basedir = os.path.join(xbmc.translatePath(addon.getAddonInfo('path')),".cache")
+addon_cache_basedir = os.path.join(xbmc.translatePath(addon.getAddonInfo('path')).decode('utf-8'),".cache")
 
 if sys.argv[1].lower() == "full":
     print "["+addon.getAddonInfo('name')+"] deleting full cache"

--- a/resources/lib/content.py
+++ b/resources/lib/content.py
@@ -20,7 +20,7 @@ INTEGRAL = 'Integral'
 def dictOfGenres(filtres):
     liste = [{'genreId': 0, 'nom': 'A %C3%A0 Z - Toutes les cat%C3%A9gories','resume':'Tout le contenu disponible.'}]
     liste.append({'genreId': 1, 'nom': 'Documentaires','resume':'Les documentaires.'})
-    liste.append({'genreId': 2, 'nom': 'Famille', 'resume':'Pour toute la famill.e'})
+    liste.append({'genreId': 2, 'nom': 'Famille', 'resume':'Pour toute la famille.'})
     liste.append({'genreId': 3, 'nom': 'Films','resume':'Les films.'})
     liste.append({'genreId': 6, 'nom': 'Jeunesse - tout-petits','resume':'Pour les petits.'})
     liste.append({'genreId': 4, 'nom': 'Jeunesse - grands','resume':'Pour les plus grands.'})

--- a/resources/lib/content.py
+++ b/resources/lib/content.py
@@ -1,6 +1,5 @@
-# -*- coding: cp1252 -*-
+# -*- coding: utf-8 -*-
 
-""" -*- coding: utf-8 -*- """
 # version 3.0.0 - By CB
 
 import urllib2, simplejson, parse, cache, re, xbmcaddon

--- a/resources/lib/html.py
+++ b/resources/lib/html.py
@@ -1,40 +1,41 @@
-# -*- coding: cp1252 -*-
+# -*- coding: utf-8 -*-
 
-""" -*- coding: utf-8 -*- """
 # version 3.0.0 - By CB
 # version 2.0.2 - By SlySen
 # version 0.2.6 - By CB
 
-import urllib2,re, socket
+import re
+import socket
+import urllib2
 
 
-# Merci ‡ l'auteur de cette fonction
+# Merci √† l'auteur de cette fonction
 def unescape_callback(matches):
     """ function docstring """
-    html_entities =\
+    html_entities = \
     {
         'quot':'\"', 'amp':'&', 'apos':'\'', 'lt':'<',
-        'gt':'>', 'nbsp':' ', 'copy':'©', 'reg':'Æ',
-        'Agrave':'¿', 'Aacute':'¡', 'Acirc':'¬',
-        'Atilde':'√', 'Auml':'ƒ', 'Aring':'≈',
-        'AElig':'∆', 'Ccedil':'«', 'Egrave':'»',
-        'Eacute':'…', 'Ecirc':' ', 'Euml':'À',
-        'Igrave':'Ã', 'Iacute':'Õ', 'Icirc':'Œ',
-        'Iuml':'œ', 'ETH':'–', 'Ntilde':'—',
-        'Ograve':'“', 'Oacute':'”', 'Ocirc':'‘',
-        'Otilde':'’', 'Ouml':'÷', 'Oslash':'ÿ',
-        'Ugrave':'Ÿ', 'Uacute':'⁄', 'Ucirc':'€',
-        'Uuml':'‹', 'Yacute':'›', 'agrave':'‡',
-        'aacute':'·', 'acirc':'‚', 'atilde':'„',
-        'auml':'‰', 'aring':'Â', 'aelig':'Ê',
-        'ccedil':'Á', 'egrave':'Ë', 'eacute':'È',
-        'ecirc':'Í', 'euml':'Î', 'igrave':'Ï',
-        'iacute':'Ì', 'icirc':'Ó', 'iuml':'Ô',
-        'eth':'', 'ntilde':'Ò', 'ograve':'Ú',
-        'oacute':'Û', 'ocirc':'Ù', 'otilde':'ı',
-        'ouml':'ˆ', 'oslash':'¯', 'ugrave':'˘',
-        'uacute':'˙', 'ucirc':'˚', 'uuml':'¸',
-        'yacute':'˝', 'yuml':'ˇ'
+        'gt':'>', 'nbsp':' ', 'copy':'¬©', 'reg':'¬Æ',
+        'Agrave':'√Ä', 'Aacute':'√Å', 'Acirc':'√Ç',
+        'Atilde':'√É', 'Auml':'√Ñ', 'Aring':'√Ö',
+        'AElig':'√Ü', 'Ccedil':'√á', 'Egrave':'√à',
+        'Eacute':'√â', 'Ecirc':'√ä', 'Euml':'√ã',
+        'Igrave':'√å', 'Iacute':'√ç', 'Icirc':'√é',
+        'Iuml':'√è', 'ETH':'√ê', 'Ntilde':'√ë',
+        'Ograve':'√í', 'Oacute':'√ì', 'Ocirc':'√î',
+        'Otilde':'√ï', 'Ouml':'√ñ', 'Oslash':'√ò',
+        'Ugrave':'√ô', 'Uacute':'√ö', 'Ucirc':'√õ',
+        'Uuml':'√ú', 'Yacute':'√ù', 'agrave':'√†',
+        'aacute':'√°', 'acirc':'√¢', 'atilde':'√£',
+        'auml':'√§', 'aring':'√•', 'aelig':'√¶',
+        'ccedil':'√ß', 'egrave':'√®', 'eacute':'√©',
+        'ecirc':'√™', 'euml':'√´', 'igrave':'√¨',
+        'iacute':'√≠', 'icirc':'√Æ', 'iuml':'√Ø',
+        'eth':'√∞', 'ntilde':'√±', 'ograve':'√≤',
+        'oacute':'√≥', 'ocirc':'√¥', 'otilde':'√µ',
+        'ouml':'√∂', 'oslash':'√∏', 'ugrave':'√π',
+        'uacute':'√∫', 'ucirc':'√ª', 'uuml':'√º',
+        'yacute':'√Ω', 'yuml':'√ø'
     }
 
     entity = matches.group(0)
@@ -64,9 +65,9 @@ def get_url_txt(the_url):
     """ function docstring """
     req = urllib2.Request(the_url)
     req.add_header(\
-        'User-Agent',\
-        'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:19.0) Gecko/20100101 Firefox/19.0'\
-    )
+                   'User-Agent', \
+                   'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:19.0) Gecko/20100101 Firefox/19.0'\
+                   )
     req.add_header('Accept-Charset', 'utf-8')
     response = urllib2.urlopen(req)
     link = response.read()

--- a/resources/lib/navig.py
+++ b/resources/lib/navig.py
@@ -1,6 +1,5 @@
-# -*- coding: cp1252 -*-
+# -*- coding: utf-8 -*-
 
-""" -*- coding: utf-8 -*- """
 # version 3.0.0 - By CB
 # version 2.0.2 - By SlySen
 # version 0.2.6 - By CB
@@ -140,11 +139,11 @@ def jouer_video(media_uid):
         )\
     )
     
-    # Preparer list de videos à jouer
+    # Preparer list de videos Ã  jouer
     playlist = xbmc.PlayList(xbmc.PLAYLIST_VIDEO)
     playlist.clear()
 
-    # Analyser chaque stream disponible pour trouver la meilleure qualité
+    # Analyser chaque stream disponible pour trouver la meilleure qualitÃ©
     #for play_list_item in video_json['playlistItems']:
     play_list_item =video_json['playlistItems'][0]
     
@@ -155,7 +154,7 @@ def jouer_video(media_uid):
             highest_bit_rate = stream['videoBitRate']
             stream_url = stream['url']
     if stream_url:
-        # Générer un lien compatible pour librtmp
+        # GÃ©nÃ©rer un lien compatible pour librtmp
         # rtmp_url - play_path - swf_url
         url_final = '%s playPath=%s swfUrl=%s swfVfy=true' % (\
             stream_url[:stream_url.find('mp4')],\

--- a/resources/lib/parse.py
+++ b/resources/lib/parse.py
@@ -1,5 +1,5 @@
+# -*- coding: utf-8 -*-
 
-#""" -*- coding: utf-8 -*- """
 import copy
 import content
 #from operator import itemgetter


### PR DESCRIPTION
Corrige le bogue #2 se produisant lorsqu'un chemin d'accès contient un caractère accentué, principalement sous Windows. Testé sous Windows 10 64bit avec un utilisateur comportant un caractère accentué dans son dossier d'utilisateur. Il y a d'autres petites choses à corriger, mais le décodage du chemin d'accès fonctionne adéquatement maintenant. 

Les fichiers étant encodés en UTF-8, modification (retour) de l'encodage en UTF-8, comme suggéré d'ailleurs dans plusieurs sources en ligne pour gérer adéquatement la présence de caractères accentués sous Python (particulière sous la version 2.X).

Corrige en passant une erreur de frappe.